### PR TITLE
Clean build directory on new build

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-preset-env": "^1.4.0",
     "browser-sync": "^2.18.8",
     "browser-sync-webpack-plugin": "^1.1.4",
+    "clean-webpack-plugin": "^0.1.19",
     "css-loader": "^0.28.0",
     "extract-text-webpack-plugin": "^2.1.0",
     "friendly-errors-webpack-plugin": "^1.6.1",

--- a/scripts/webpack.config.js
+++ b/scripts/webpack.config.js
@@ -4,6 +4,7 @@ const webpack = require('webpack');
 const autoprefixer = require('autoprefixer');
 const AssetsPlugin = require('assets-webpack-plugin');
 const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin');
 const path = require('path');
@@ -81,6 +82,7 @@ module.exports = {
     ],
   },
   plugins: [
+    !DEV && new CleanWebpackPlugin(['build']),
     new ExtractTextPlugin(DEV ? 'bundle.css' : 'bundle.[hash:8].css'),
     new webpack.EnvironmentPlugin({
       NODE_ENV: 'development', // use 'development' unless process.env.NODE_ENV is defined

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,10 +710,6 @@ better-assert@~1.0.0:
   dependencies:
     callsite "1.0.0"
 
-bf-solid@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/bf-solid/-/bf-solid-2.6.2.tgz#8b2f266b94fb16f341037df9587010af9eb5c585"
-
 big.js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
@@ -1008,6 +1004,12 @@ clap@^1.0.9:
   resolved "https://registry.yarnpkg.com/clap/-/clap-1.1.3.tgz#b3bd36e93dd4cbfb395a3c26896352445265c05b"
   dependencies:
     chalk "^1.1.3"
+
+clean-webpack-plugin@^0.1.19:
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-0.1.19.tgz#ceda8bb96b00fe168e9b080272960d20fdcadd6d"
+  dependencies:
+    rimraf "^2.6.1"
 
 cliui@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Because of the awesome cache busting, old build files are not overwritten when the files have changed. Maybe it could be useful to clean the build folder before a new build?