### PR TITLE
Use body_class on the body tag

### DIFF
--- a/header.php
+++ b/header.php
@@ -6,4 +6,4 @@
 		<link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>">
 		<?php wp_head(); ?>
 	</head>
-	<body>
+	<body <?php body_class(); ?>>


### PR DESCRIPTION
The post name is properly added to the collection of body classes with `add_filter('body_class', 'add_slug_to_body_class');`, but the classes themselves are never added to the body tag in the header.