### PR TITLE
Wordpress up to latest version 4.9.8, node-sass up to 4.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ new BrowserSyncPlugin({
 docker exec -it host_db_1 /usr/bin/mysqldump -u username -ppassword database_name > backup.sql
 ```
 
-##RESTORE
+## RESTORE
 ```aidl
 docker exec -i host_db_1 /usr/bin/mysqldump -u username -ppassword database_name < backup.sql
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   wordpress:
     depends_on:
       - db
-    image: wordpress:4.7.5-apache
+    image: wordpress:4.9.8-apache
     volumes:
       - ".:/var/www/html/wp-content/themes/presspack"
       - "./wp-content/plugins:/var/www/html/wp-content/plugins"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "css-loader": "^0.28.0",
     "extract-text-webpack-plugin": "^2.1.0",
     "friendly-errors-webpack-plugin": "^1.6.1",
-    "node-sass": "^4.3.0",
+    "node-sass": "^4.10.0",
     "postcss-loader": "^1.3.3",
     "sass-loader": "^6.0.3",
     "style-loader": "^0.16.1",


### PR DESCRIPTION
Update Wordpress to latest version 4.9.8
Update node-sass to latest 4.10.0 (version 4.3.0 have problem with python on windows)
fix in readme