### PR TITLE
Fix "Local Database Restore" command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ docker exec -it host_db_1 /usr/bin/mysqldump -u username -ppassword database_nam
 Restore a previous database backup
 
 ```aidl
-docker exec -i host_db_1 /usr/bin/mysqldump -u username -ppassword database_name < backup.sql
+docker exec -i host_db_1 /usr/bin/mysql -u username -ppassword database_name < backup.sql
 ```
 
 ## Author


### PR DESCRIPTION
The command to restore a previous database backup in README is wrong. This one-line fix changes it from `mysqldump < backup.sql` to `mysql < backup.sql`.