### PR TITLE
Add ports to mysql in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '2'
 services:
   db:
     image: mysql:5.7
+    ports:
+      - 3306:3306
     volumes:
       - "./.data/db:/var/lib/mysql"
     restart: always


### PR DESCRIPTION
The addition of ports for mysql opens up mysql clients ability to connect to the container database which can be helpful during development.