### PR TITLE
Update wordpress, node-sass, chown info

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,12 @@ new BrowserSyncPlugin({
         └── camelCase.js         # Helper function for Router, DO NOT TOUCH
 ```
 
+## Problem with update wordpress or plugins?
+You need to run the `chown` command inside docker container
+```
+RUN chown -R www-data:www-data /var/www
+```
+
 ## Local Database Backup
 
 Here's how to dump your local database with Docker into a `.sql` file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   wordpress:
     depends_on:
       - db
-    image: wordpress:5.2.3-apache
+    image: wordpress:5.4.1-apache
     volumes:
       - "./template:/var/www/html/wp-content/themes/presspack"
       - "./build:/var/www/html/wp-content/themes/presspack/build"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "css-loader": "^2.0.0",
     "friendly-errors-webpack-plugin": "^1.7.0",
     "mini-css-extract-plugin": "^0.5.0",
-    "node-sass": "^4.10.0",
+    "node-sass": "^4.14.1",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "postcss-loader": "^3.0.0",
     "sass-loader": "^7.0.0",


### PR DESCRIPTION
Update wordpress to lates version: 5.4.1
Update node-sass to latest version: 4.14.1 (because node install can't install dependencies)
Add short info about setting chown if can't install/update plugin, theme etc.